### PR TITLE
Regarding search suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This is primarily my personal fork to experiment with PWAs but I do have a few i
 
 I would love to add these but they don't seem possible / feasible at the moment:
 - [ ] ~Search suggestions~ (as far as I can tell this essentially impossible to do natively with either firefox or chrome; please correct me if I'm wrong though. In this case I would very much love to be wrong)
-- [x] ~Weekly bang checks to ensure that all bangs still work and excludes those that don't~ this ended up being unreliable because of cloudflare rate limiting and switching to kagi bangs helped a lot with this
+- [x] ~Weekly bang checks to ensure that all bangs still work and excludes those that don't~ (this ended up being unreliable because of cloudflare rate limiting and switching to kagi bangs helped a lot with this)
 
 ## Fancy smancy technical graphs 😮
 


### PR DESCRIPTION
I can't open an issue in this repo, so I'm just making this PR instead. This is just potentially useful info I found and tested that you can put in the README:

Some browsers (at least Firefox-based ones) allow you to designate a URL for search suggestions in the search engine settings:

![image](https://github.com/user-attachments/assets/dc1024f5-f0ff-4c3f-8813-6e15ebecb04c)

This allows you to get search suggestions even when using Unduckified. (It is now my default search engine.)

I only checked Firefox, Zen, and a vanilla Chromium browser, and only Firefox and Zen had this option.

I found that for search suggestions from DuckDuckGo you can use `https://duckduckgo.com/ac/?q=%s&type=list`. And for Google search suggestions you can use `https://www.google.com/complete/search?client=chrome&q=%s`.

Credit to the answers in [this thread](https://forum.vivaldi.net/topic/91329/duckduckgo-search-suggestion-url-in-address-bar) and [this thread](https://www.reddit.com/r/vivaldibrowser/comments/55fjja/suggest_url_for_google_suggestions/).
