### PR TITLE
feat: allow using a custom bang as the default bang

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -146,7 +146,7 @@ const createTemplate = (data: {
 					<h2>Settings</h2>
 					<div class="settings-section">
 					    <h3>Bangs</h3>
-							<label for="default-bang" id="bang-description">Default Bang: ${bangs[data.LS_DEFAULT_BANG].s || "Unknown bang"}</label>
+							<label for="default-bang" id="bang-description">Default Bang: ${defaultBang?.s || "Unknown bang"}</label>
 							<div class="bang-select-container">
 									<input type="text" id="default-bang" class="bang-select" value="${data.LS_DEFAULT_BANG}">
 							</div>
@@ -506,7 +506,7 @@ function noSearchDefaultPageRender() {
 
 const LS_DEFAULT_BANG =
 	storage.get(CONSTANTS.LOCAL_STORAGE_KEYS.DEFAULT_BANG) ?? "ddg";
-const defaultBang = bangs[LS_DEFAULT_BANG];
+const defaultBang = bangs[LS_DEFAULT_BANG] || customBangs[LS_DEFAULT_BANG];
 
 function ensureProtocol(url: string, defaultProtocol = "https://") {
 	try {


### PR DESCRIPTION
I was trying to use my custom bang as a default search (basically, Google adding the `-ai` flag), and the webpage _did_ allow me to do that on the UI, but everything exploded afterwards.

First, it gave me a good ol' `TypeError: Cannot read properties of undefined (reading 's')` on `main.ts:L151`, because it was not finding the default bang, and after I solved that, I just had to update the `defaultBang` variable and everything works!