### PR TITLE
Fallback to default bang when specified bang is not found

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -536,12 +536,18 @@ function getBangredirectUrl() {
 			storage.set(CONSTANTS.LOCAL_STORAGE_KEYS.SEARCH_COUNT, count);
 
 			const match = query.toLowerCase().match(/^!(\S+)|!(\S+)$/i);
-			const selectedBang = match
+			let selectedBang = match
 				? customBangs[match[1] || match[2]] || bangs[match[1] || match[2]]
 				: defaultBang;
-			const cleanQuery = match
+			let cleanQuery = match
 				? query.replace(/!\S+\s*|^(\S+!|!\S+)$/i, "").trim()
 				: query;
+
+			if (selectedBang === undefined) {
+				// invalid bang, fallback to default
+				selectedBang = defaultBang;
+				cleanQuery = query;  // use full query, as DuckDuckGo does
+			}
 
 			// Redirect to base domain if cleanQuery is empty
 			if (!cleanQuery && selectedBang?.d) {


### PR DESCRIPTION
When the specified bang is not found, e.g. searching `test !invalid-bang`, it gave an error (`Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'toLowerCase')`), and did nothing.

We now redirect to the default bang, _keeping_ the `!invalid-bang` part, as it's what DuckDuckGo does in this case.